### PR TITLE
Miscellaneous changes to TWiR template

### DIFF
--- a/drafts/YYYY-MM-DD-this-week-in-rust-template.md
+++ b/drafts/YYYY-MM-DD-this-week-in-rust-template.md
@@ -4,13 +4,13 @@ Category: This Week in Rust
 
 Hello and welcome to another issue of *This Week in Rust*!
 [Rust](http://rust-lang.org) is a systems language pursuing the trifecta:
-safe, concurrent, and fast. This is a weekly summary of its progress and
+safety, concurrency, and speed. This is a weekly summary of its progress and
 community. Want something mentioned? [Send me an
 email!](mailto:corey@octayn.net?subject=This%20Week%20in%20Rust%20Suggestion)
 Want to get involved? [We love
-contributions](https://github.com/mozilla/rust/wiki/Note-guide-for-new-contributors).
+contributions](https://github.com/rust-lang/rust/wiki/Note-guide-for-new-contributors).
 
-This Week in Rust is openly developed [on Github](https://github.com/cmr/this-week-in-rust).
+*This Week in Rust* is openly developed [on GitHub](https://github.com/cmr/this-week-in-rust).
 If you find any errors or omissions in this week's issue, [please submit a PR](https://github.com/cmr/this-week-in-rust/pulls).
 
 # What's cooking on master?


### PR DESCRIPTION
- Link to rust-lang/rust instead of mozilla/rust.
- Italicize *This Week in Rust*.
- Change capitalization of "GitHub".
- Use nouns rather than adjectives to describe the Rust trifecta.