### PR TITLE
reader-friendly title

### DIFF
--- a/drafts/YYYY-MM-DD-this-week-in-rust-template.md
+++ b/drafts/YYYY-MM-DD-this-week-in-rust-template.md
@@ -1,4 +1,4 @@
-Title: This Week in Rust XX
+Title: This Week in Rust. #XX
 Date: YYYY-MM-DD
 Category: This Week in Rust
 


### PR DESCRIPTION
Proposing change as [advised by SimonSapin@reddit](https://www.reddit.com/r/rust/comments/2tw2w1/this_week_in_rust_67/co3dmec?context=3)

Original title is instinctively read as "This Week in Rust-67" and I keep wondering what is this "Rust-67" for next 5 seconds
(movie sequels are to be blamed, I believe) :)