### PR TITLE
Fixed a spelling error

### DIFF
--- a/content/2015-02-23-this-week-in-rust.md
+++ b/content/2015-02-23-this-week-in-rust.md
@@ -223,7 +223,7 @@ Friend of the Tree."
 * [Radical statements about the mobile web][radical]. Servo is going to fix it al.
 * [Embedded Rust Right Now!][now].
 * [On Rust and Nim][nim]. [HN][nim-hn].
-* [Rust Debuging in Emacs][emacs].
+* [Rust Debugging in Emacs][emacs].
 * [Thoughts of a Rustacean learning Go][go]. [/r/rust][go-r-rust].
 * [Some notes on Send and Sync][sendand].
 * [Turing tarpits in Rust's macro system][tarp].


### PR DESCRIPTION
Rust Debuging in Emacs. > Rust Debugging in Emacs.