### PR TITLE
Update title of pull request to reflect actual commit

### DIFF
--- a/content/2015-04-27-this-week-in-rust.md
+++ b/content/2015-04-27-this-week-in-rust.md
@@ -33,7 +33,7 @@ Now you can follow breaking changes *[as they happen][BitRust2]*!
 
 # Other Changes
 
-* [Rename std::fs::soft_link to std::fs::symlink](https://github.com/rust-lang/rust/pull/24222)
+* [Deprecate `std::fs::soft_link` in favor of platform-specific versions](https://github.com/rust-lang/rust/pull/24222)
 * [Introduce a `FreeRegionMap` to store relations between free regions](https://github.com/rust-lang/rust/pull/24553)
 * [implement rfc 1054: split_whitespace() fn, deprecate words()](https://github.com/rust-lang/rust/pull/24563)
 * [implement set_tcp_keepalive for linux](https://github.com/rust-lang/rust/pull/24594)


### PR DESCRIPTION
Since originally creating it, I had changed "Rename std::fs::soft_link to std::fs::symlink" into "Deprecate std::fs::soft_link in favor of platform-specific versions". I had fixed the title of the actual commit, but not the pull request. I've now fixed the pull request, and should update TWIR to reflect what the change actually does.