### PR TITLE
Updating the link to "all posts" on the front page

### DIFF
--- a/themes/pelican-elegant-1.3/templates/index.html
+++ b/themes/pelican-elegant-1.3/templates/index.html
@@ -40,7 +40,7 @@
     <div class="row-fluid">
         <div class="span12">
             <header>
-            <h1 id="recent-posts">Recent Posts <a id="allposts" href="{{ SITEURL }}/archives.html">all posts</a></h1>
+            <h1 id="recent-posts">Recent Posts <a id="allposts" href="{{ SITEURL }}/blog/archives/index.html">all posts</a></h1>
             </header>
             {% for article in articles %}
             {% if not RECENT_ARTICLES_COUNT %}


### PR DESCRIPTION
The all posts link should point to /blog/archives/index.html. This fixes #56.