### PR TITLE
Add a summary of the changes to rustbyexample over the past few months

### DIFF
--- a/drafts/2015-06-22-this-week-in-rust.md
+++ b/drafts/2015-06-22-this-week-in-rust.md
@@ -21,6 +21,21 @@ This week's edition was edited by: WHO??
 
 # Project Updates
 
+* A summary of the major changes to [Rust by example](http://rustbyexample.com/)
+in the past few months include:
+ - February 15, 2015: The [flow control section](http://rustbyexample.com/flow_control.html)
+was [created](https://github.com/rust-lang/rust-by-example/pull/421) to house
+all flow control operations together.
+ - March 21, 2015: The [formatting section](http://rustbyexample.com/hello/print.html)
+was [revised](https://github.com/rust-lang/rust-by-example/pull/496) so new
+users are immediately confronted with the distinction of `Debug` and `Display`
+and how to deal with them.
+ - May 2, 2015: The table of contents was [reorganized](https://github.com/rust-lang/rust-by-example/pull/561)
+so examples are sorted consistently by categories.
+ - May 23, 2015: The [generics section](http://rustbyexample.com/generics.html) was
+majorly [expanded](https://github.com/rust-lang/rust-by-example/pull/572).
+ - June 15, 2015: The [closures section](http://rustbyexample.com/fn/closures.html) was
+completely rewritten and [expanded](https://github.com/rust-lang/rust-by-example/pull/594).
 
 # What's cooking on master?
 


### PR DESCRIPTION
@brson Here's a list of the major changes to rbe. I tried to be brief as they can look at the PR if they want more info. I'm not sure if I should have left the dates but it seems okay.

I don't particularly like that the only major changes I found were written by me but that's what I found. There is https://github.com/rust-lang/rust-by-example/pull/583 which is an interesting minor change but it still hasn't merged.