### PR TITLE
Added link to Twitter account

### DIFF
--- a/drafts/2015-06-22-this-week-in-rust.md
+++ b/drafts/2015-06-22-this-week-in-rust.md
@@ -5,15 +5,15 @@ Category: This Week in Rust
 Hello and welcome to another issue of *This Week in Rust*!
 [Rust](http://rust-lang.org) is a systems language pursuing the trifecta:
 safety, concurrency, and speed. This is a weekly summary of its progress and
-community. Want something mentioned? [Send me an
-email!](mailto:corey@octayn.net?subject=This%20Week%20in%20Rust%20Suggestion)
+community. Want something mentioned? Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) or [send us an
+email](mailto:corey@octayn.net?subject=This%20Week%20in%20Rust%20Suggestion)!
 Want to get involved? [We love
 contributions](https://github.com/rust-lang/rust/wiki/Note-guide-for-new-contributors).
 
 *This Week in Rust* is openly developed [on GitHub](https://github.com/cmr/this-week-in-rust).
-If you find any errors or omissions in this week's issue, [please submit a PR](https://github.com/cmr/this-week-in-rust/pulls).
+If you find any errors in this week's issue, [please submit a PR](https://github.com/cmr/this-week-in-rust/pulls).
 
-This week's edition was edited by: Vikrant Chaudhary, mdinger, Andrew Gallant, and Brian Anderson
+This week's edition was edited by: [Brian Anderson](https://github.com/brson), [Vikrant Chaudhary](https://github.com/nasa42), [Andrew Gallant](https://github.com/BurntSushi), and [mdinger](https://github.com/mdinger).
 
 # From Blogosphere
 

--- a/drafts/YYYY-MM-DD-this-week-in-rust-template.md
+++ b/drafts/YYYY-MM-DD-this-week-in-rust-template.md
@@ -5,13 +5,13 @@ Category: This Week in Rust
 Hello and welcome to another issue of *This Week in Rust*!
 [Rust](http://rust-lang.org) is a systems language pursuing the trifecta:
 safety, concurrency, and speed. This is a weekly summary of its progress and
-community. Want something mentioned? [Send me an
-email!](mailto:corey@octayn.net?subject=This%20Week%20in%20Rust%20Suggestion)
+community. Want something mentioned? Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) or [send us an
+email](mailto:corey@octayn.net?subject=This%20Week%20in%20Rust%20Suggestion)!
 Want to get involved? [We love
 contributions](https://github.com/rust-lang/rust/wiki/Note-guide-for-new-contributors).
 
 *This Week in Rust* is openly developed [on GitHub](https://github.com/cmr/this-week-in-rust).
-If you find any errors or omissions in this week's issue, [please submit a PR](https://github.com/cmr/this-week-in-rust/pulls).
+If you find any errors in this week's issue, [please submit a PR](https://github.com/cmr/this-week-in-rust/pulls).
 
 This week's edition was edited by: WHO??
 


### PR DESCRIPTION
Also, replaced "me" with "us", removed "omissions" word (because we should treat past issues as readonly and any "omissions" should be part of a new issue), and sorted contributors by last name.