### PR TITLE
Creates ids for headers on articles

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -35,3 +35,5 @@ A weekly newsletter about Rust and the Rust community, with bonus content
 scattered about.
 """
 }
+
+MD_EXTENSIONS = ['headerid']


### PR DESCRIPTION
With the id attribute on the headers it would be able to link to a
specific section of the page when sharing with someone.

Extension suggestion comes from https://github.com/getpelican/pelican/issues/1357