### PR TITLE
add jobs section

### DIFF
--- a/drafts/2015-07-27-this-week-in-rust.md
+++ b/drafts/2015-07-27-this-week-in-rust.md
@@ -95,6 +95,12 @@ Anderson][brson] for access.
 [erickt]: mailto:erick.tryzelaar@gmail.com
 [brson]: mailto:banderson@mozilla.com
 
+# fn work(on: RustProject) -> Money
+
+* Assistant Researcher in Karlsruhe, Germany for embedded development on ARM stm32. Contact [Oliver Schneider][oli_obk]
+
+[oli_obk]: mailto:oliver.schneider@kit.edu
+
 # Quote of the Week
 
 *"Quote"*


### PR DESCRIPTION
see https://users.rust-lang.org/t/this-week-in-rust-editors-thread/1806/39?u=oli_obk

for now I suggest adding them manually. if it gets more frequent, a thread as suggested by @nasa42 is probably the way to go.

Open question is whether they should get removed in the next or second next issue automatically.