### PR TITLE
mistranslation of job title

### DIFF
--- a/content/2015-07-27-this-week-in-rust.md
+++ b/content/2015-07-27-this-week-in-rust.md
@@ -155,7 +155,7 @@ Anderson][brson] for access.
 
 There are some jobs writing Rust! This week's listings:
 
-* Assistant Researcher in Karlsruhe, Germany for embedded development on ARM stm32. Contact [Oliver Schneider][oli_obk]
+* Student Research Assistant in Karlsruhe, Germany for embedded development on ARM stm32. Contact [Oliver Schneider][oli_obk]
 
 [oli_obk]: mailto:oliver.schneider@kit.edu
 


### PR DESCRIPTION
Not sure if corrections are allowed (and would be published) for released TWIRs...

The german `HiWi` (Hilfs-Wissenschaftler) means `student research assistant`, not `research assistant`