### PR TITLE
Fix title of article pages

### DIFF
--- a/themes/rusted/templates/article.html
+++ b/themes/rusted/templates/article.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-{{ article.title }} {%if article.subtitle %} - {{ article.subtitle }} {% endif %} Â· {{ super() }}
+{{ article.title }} {%if article.subtitle %} - {{ article.subtitle }} {% endif %} · {{ super() }}
 {% endblock title %}
 
 {% block head_description %}


### PR DESCRIPTION
Remove a `Â` character that has sneaked in.