### PR TITLE
TWiR release 91 (10 August 2015).

### DIFF
--- a/content/2015-08-10-this-week-in-rust.md
+++ b/content/2015-08-10-this-week-in-rust.md
@@ -1,0 +1,119 @@
+Title: This Week in Rust 91
+Date: 2015-08-10
+Category: This Week in Rust
+
+Hello and welcome to another issue of *This Week in Rust*!
+[Rust](http://rust-lang.org) is a systems language pursuing the trifecta:
+safety, concurrency, and speed. This is a weekly summary of its progress and
+community. Want something mentioned? Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) or [send us an
+email](mailto:corey@octayn.net?subject=This%20Week%20in%20Rust%20Suggestion)!
+Want to get involved? [We love
+contributions](https://github.com/rust-lang/rust/wiki/Note-guide-for-new-contributors).
+
+*This Week in Rust* is openly developed [on GitHub](https://github.com/cmr/this-week-in-rust).
+If you find any errors in this week's issue, [please submit a PR](https://github.com/cmr/this-week-in-rust/pulls).
+
+# From the Blogosphere
+
+* <img alt="balloon" class="emoji" title=":balloon:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/balloon.png?v=0"><img alt="tada" class="emoji" title=":tada:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/tada.png?v=0"> [Announcing Rust 1.2](http://blog.rust-lang.org/2015/08/06/Rust-1.2.html). <img alt="tada" class="emoji" title=":tada:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/tada.png?v=0"><img alt="balloon" class="emoji" title=":balloon:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/balloon.png?v=0">
+* [Writing Unsafe and Low-Level Code in Rust](http://smallcultfollowing.com/rust-int-variations/imem-umem/guide-unsafe.html).
+* [Creating a PHP Extension to Rust](http://hermanradtke.com/2015/08/03/creating-a-php-extension-to-rust.html).
+* [Objective-C from Rust: objc_msgSend](http://sasheldon.com/blog/2015/08/02/objective-c-from-rust-objc_msgsend/).
+* [A Simple Web App in Rust, Part 4 -- CLI Option Parsing](https://joelmccracken.github.io/entries/a-simple-web-app-in-rust-pt-4--cli-option-parsing/).
+* [video] [The Rust Programming Language](https://youtu.be/d1uraoHM8Gg) from Google TechTalks.
+
+# New Releases & Project Updates
+
+* [rust-cpp](https://github.com/mystor/rust-cpp). Embed C++ directly inside your rust code.
+* [rustty](https://github.com/cpjreynolds/rustty). A terminal UI library.
+* [coalesce-rs](https://github.com/arcnmx/coalesce-rs). Combine disjoint types that share common traits.
+* [mdBook](https://github.com/azerupi/mdBook). Create a book from markdown files.
+* [Serde 0.5.0 adds support for bincode](https://erickt.github.io/blog/2015/08/07/serde-0-dot-5-0-many-many-changes/).
+
+# What's cooking on nightly?
+
+XXX pull requests were [merged in the last week][merged].
+
+[merged]: https://github.com/issues?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2015-05-18..2015-06-07
+
+# New Contributors
+
+
+
+# Approved RFCs
+
+Changes to Rust follow the Rust [RFC (request for comments)
+process](https://github.com/rust-lang/rfcs#rust-rfcs). These
+are the RFCs that were approved for implementation this week:
+
+
+# Final Comment Period
+
+Every week [the team](https://rust-lang.org/team.html) announces the
+'final comment period' for RFCs and key PRs which are reaching a
+decision. Express your opinions now. [This week's FCPs][fcp] are:
+
+[fcp]: https://github.com/issues?utf8=%E2%9C%93&q=is%3Apr+org%3Arust-lang+label%3Afinal-comment-period+is%3Aopen+updated%3A2015-07-06..2015-07-13
+
+* TODO
+
+# New RFCs
+
+
+# Friend of the Tree
+
+[The Rust Team](http://www.rust-lang.org/team.html) likes to
+occasionally recognize people who have made
+outstanding contributions to The Rust Project, its ecosystem, and its
+community. These people are 'friends of the tree'.
+
+[This week's friend of the tree](TODO) was ...
+
+
+# Subteam reports
+
+Every week [The Rust Team](http://www.rust-lang.org/team.html) release
+a report on what is going on in their corner of the project. Here are
+the highlights from [this week's report](TODO).
+
+* TODO
+
+# Internals discussions
+
+# Crate of the Week
+
+There are so many crates! It's easy to lose track of the good ones,
+like [THING].
+
+THING is a ...
+
+
+# Upcoming Events
+
+* [What?]
+
+If you are running a Rust event please add it to the [calendar] to get
+it mentioned here. Email [Erick Tryzelaar][erickt] or [Brian
+Anderson][brson] for access.
+
+[calendar]: https://www.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com
+[erickt]: mailto:erick.tryzelaar@gmail.com
+[brson]: mailto:banderson@mozilla.com
+
+# fn work(on: RustProject) -> Money
+
+There are some jobs writing Rust! This week's listings:
+
+* TODO
+
+(Don't forget to re-list last-week's).
+
+# Quote of the Week
+
+*"Quote"*
+
+Explanation and link.
+
+Thanks to XXX for the tip. [Submit your quotes for next week!][submit].
+
+[submit]: http://users.rust-lang.org/t/twir-quote-of-the-week/328

--- a/themes/pelican-elegant-1.3/static/css/style.css
+++ b/themes/pelican-elegant-1.3/static/css/style.css
@@ -416,3 +416,10 @@ a#allposts {
         width: inherit;
     }
 }
+
+.emoji {
+    width: 20px;
+    height: 20px;
+    vertical-align: middle;
+    border: 0px none;
+}


### PR DESCRIPTION
For now, directly added links to some emoticons. Later, should extend Markdown to parse emoticon :tags:.