### PR TITLE
Pelican might not support fenced code blocks?

### DIFF
--- a/content/2015-08-10-this-week-in-rust.md
+++ b/content/2015-08-10-this-week-in-rust.md
@@ -190,11 +190,9 @@ There are some jobs writing Rust! This week's listings:
 
 # Quote of the Week
 
-```
-<bluss> I've tried using unchecked indexing in non-trivial code now a couple of times. It never makes a big difference
-<bluss> Profiling shows like 1-2% improvement if that
-<bluss> so it's the tightest loops you should worry about, not much more
-```
+    <bluss> I've tried using unchecked indexing in non-trivial code now a couple of times. It never makes a big difference
+    <bluss> Profiling shows like 1-2% improvement if that
+    <bluss> so it's the tightest loops you should worry about, not much more
 
 @bluss knows a few things about micro-optimization.
 


### PR DESCRIPTION
The quote of the week is formatted on http://this-week-in-rust.org/blog/2015/08/10/this-week-in-rust-91/ as inline code without line breaks. Maybe the flavor of Markdown used by Pelican does not support fenced (triple backticks) code blocks? Try the indented syntax instead.