### PR TITLE
Transforms the URL to the content on a Markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 this-week-in-rust
 =================
 
-Content for this-week-in-rust.org. Made available under CC-BY-SA.
+Content for [this-week-in-rust.org](http://this-week-in-rust.org). Made available under CC-BY-SA.
 
 All code Copyright 2014 Corey Richardson, made available under [the MIT
 license](http://mit-license.org/).


### PR DESCRIPTION
I was reading the rendered README.md on Github but I missed the URL searching for a blue text.

This changes transforms the URL into a clickable link to make it easier to find when skimming.