### PR TITLE
Add the subteam report to 2015-09-07

### DIFF
--- a/content/2015-09-07-this-week-in-rust.md
+++ b/content/2015-09-07-this-week-in-rust.md
@@ -40,6 +40,10 @@ This week's edition was edited by: [nasa42](https://github.com/nasa42) and [llog
 
 [merged]: https://github.com/issues?q=is%3Apr+org%3Arust-lang+is%3Amerged+merged%3A2015-08-31..2015-09-07
 
+See the [subteam report for 2015-09-04][subteam] for details.
+
+[subteam]: https://internals.rust-lang.org/t/subteam-reports-2015-09-04/2600
+
 # New Contributors
 
 * Aleksey Kladov


### PR DESCRIPTION
r? @nasa42 I'm still not sure the best way to integrate the subteam reports but this seems good enough today.

cc @cmr I can't deploy this today because I am separated from my ssh keys. If you find yourself near yours, and inclined to Rust, will you deploy this edition?