### PR TITLE
Fix encoding issue in title in article template

### DIFF
--- a/themes/rusted/templates/article.html
+++ b/themes/rusted/templates/article.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-{{ article.title }} {%if article.subtitle %} - {{ article.subtitle }} {% endif %} Â· {{ super() }}
+{{ article.title }} {%if article.subtitle %} - {{ article.subtitle }} {% endif %} · {{ super() }}
 {% endblock title %}
 
 {% block head_description %}


### PR DESCRIPTION
The title containted 'Â·' string, which probably was a result of re-encoding UTF-8 as UTF-8. Replaced with '·'.