### PR TITLE
Disable Fira Sans

### DIFF
--- a/themes/rusted/static/css/main.scss
+++ b/themes/rusted/static/css/main.scss
@@ -4,7 +4,7 @@
 $screen-xs-max: 768px !default;
 
 // Our variables
-$base-font-family: 'Fira Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+$base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $base-font-size:   16px;
 $small-font-size:  $base-font-size * 0.875;
 $base-line-height: 1.5;

--- a/themes/rusted/templates/base.html
+++ b/themes/rusted/templates/base.html
@@ -30,7 +30,6 @@
 
     <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME|striptags }} - Full Atom Feed" />
 
-    <link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,500,500italic|Fira+Mono:400' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     {% assets filters="scss,cssmin", output="css/web-min.css", "css/main.scss" %}
     <link rel="stylesheet" href="/{{ ASSET_URL }}">


### PR DESCRIPTION
With Fira Sans as the first font listed, the text is invisible in Firefox on Linux.