### PR TITLE
Fix contributions link in latest newsletter

### DIFF
--- a/content/2015-10-05-this-week-in-rust.md
+++ b/content/2015-10-05-this-week-in-rust.md
@@ -9,7 +9,7 @@ safety, concurrency, and speed. This is a weekly summary of its progress and
 community. Want something mentioned? Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) or [send us an
 email](mailto:corey@octayn.net?subject=This%20Week%20in%20Rust%20Suggestion)!
 Want to get involved? [We love
-contributions](https://github.com/rust-lang/rust/wiki/Note-guide-for-new-contributors).
+contributions](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md).
 
 *This Week in Rust* is openly developed [on GitHub](https://github.com/cmr/this-week-in-rust).
 If you find any errors in this week's issue, [please submit a PR](https://github.com/cmr/this-week-in-rust/pulls).


### PR DESCRIPTION
Even though `drafts/YYYY-MM-DD-this-week-in-rust.md` has the correct contributions link, all recent newsletters seem to use the old wiki link (https://github.com/rust-lang/rust/wiki/Note-guide-for-new-contributors). I only changed the contrib link on the latest newsletter, but I'm happy to update the links on older ones too.