### PR TITLE
remove Rust-Berlin meetup on 23.12.

### DIFF
--- a/content/2015-12-14-this-week-in-rust.md
+++ b/content/2015-12-14-this-week-in-rust.md
@@ -94,7 +94,6 @@ decision. Express your opinions now. [This week's FCPs][fcp] are:
 * [12/15. Rust - Rethinking Systems Programming](http://www.meetup.com/de/NewStore/events/225945950/).
 * [12/16. SSD Rust meetup - servo + TBD topics](http://www.meetup.com/SolidStateDepot/events/227170190/).
 * [12/21. Paris - Rust Paris](http://www.meetup.com/Rust-Paris).
-* [12/23. RustBerlin Hack and Learn](http://www.meetup.com/Rust-Berlin/).
 
 If you are running a Rust event please add it to the [calendar] to get
 it mentioned here. Email [Erick Tryzelaar][erickt] or [Brian


### PR DESCRIPTION
The bi-weekly Rust Hack and Learn in Berlin is in holiday mode for the next two meetups (23.12. and 06.01).

After that the Hack and Learns are hosted under http://www.meetup.com/opentechschool-berlin/ instead of http://www.meetup.com/rust-berlin/ .

@skade I think you are the only one who can adjust the events in the [calendar](https://calendar.google.com/calendar/embed?src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com) since you created them?