### PR TITLE
Improve Quote Readability

### DIFF
--- a/themes/rusted/static/css/_base.scss
+++ b/themes/rusted/static/css/_base.scss
@@ -111,7 +111,6 @@ blockquote {
     border-left: 4px solid $grey-colour-light;
     padding-left: $spacing-unit / 2;
     font-size: 18px;
-    letter-spacing: -1px;
     font-style: italic;
 
     > :last-child {


### PR DESCRIPTION
If someone really wants a narrow font, they should use a font that is narrow (and not manually adjust the letter spacing for small text sizes).