### PR TITLE
Create RSS feed and be https

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -5,7 +5,7 @@ import os
 
 AUTHOR = u'Corey Richardson'
 SITENAME = u"This Week in Rust"
-SITEURL = 'http://this-week-in-rust.org'
+SITEURL = 'https://this-week-in-rust.org'
 
 SOURCE_URL = 'https://github.com/cmr/this-week-in-rust'
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -23,7 +23,9 @@ DEFAULT_LANG = u'en'
 
 FEED_DOMAIN = SITEURL
 FEED_ALL_ATOM = 'atom.xml'
+FEED_ALL_RSS = 'rss.xml'
 CATEGORY_FEED_ATOM = 'categories/%s/atom.xml'
+CATEGORY_FEED_RSS = 'categories/%s/rss.xml'
 
 DEFAULT_PAGINATION = 10
 

--- a/themes/rusted/templates/base.html
+++ b/themes/rusted/templates/base.html
@@ -29,6 +29,7 @@
     {% endblock head_links %}
 
     <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME|striptags }} - Full Atom Feed" />
+    <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME|striptags }} - Full RSS Feed" />
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     {% assets filters="scss,cssmin", output="css/web-min.css", "css/main.scss" %}
@@ -56,6 +57,7 @@
             <ul class="list-unstyled">
               <li><a href="{{ SITEURL }}/blog/archives/index.html">past issues</a></li>
               <li><a href="{{ SITEURL }}/{{ FEED_ALL_ATOM }}">atom feed</a></li>
+              <li><a href="{{ SITEURL }}/{{ FEED_ALL_RSS }}">rss feed</a></li>
               <li><a href="{{ SOURCE_URL }}">source code</a></li>
             </ul>
           </div>


### PR DESCRIPTION
I fixed settings and template to create RSS feed for some old readers (e.g. Nokia N9 embedded reader) that know nothing about Atom.

I also fixed SITEURL since the site is fully HTTPS, HSTS-enabled and HTTP-disabled now.