### PR TITLE
Update link to TWIA 7

### DIFF
--- a/drafts/2016-03-14-this-week-in-rust.md
+++ b/drafts/2016-03-14-this-week-in-rust.md
@@ -20,7 +20,7 @@ This week's edition was edited by: [Vikrant](https://github.com/nasa42) and [llo
 
 ## News & Blog Posts
 
-* [These weeks in Amethyst 7](blog.amethyst.rs/2016/03/13/twia-7/).
+* [These weeks in Amethyst 7](http://blog.amethyst.rs/2016/03/13/twia-7/).
 
 ## Notable New Crates & Project Updates
 


### PR DESCRIPTION
Forgot the `http://` prefix, so the link incorrectly attempted to load from the current directory.