### PR TITLE
added missing MIR bootstrap change

### DIFF
--- a/content/2016-03-21-this-week-in-rust.md
+++ b/content/2016-03-21-this-week-in-rust.md
@@ -81,6 +81,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 ## Notable changes
 
 * [RFC 1210 impl specialization has landed!](https://github.com/rust-lang/rust/pull/30652) Yay!
+* [MIR is now able to bootstrap itself...into orbit!](https://github.com/rust-lang/rust/pull/32080)
 * [typestrong const integers](https://github.com/rust-lang/rust/pull/30587) (breaking change)
 * [Fast floating point algebra](https://github.com/rust-lang/rust/pull/32256)
 * [#derive now uses intrinsics::unreachable](https://github.com/rust-lang/rust/pull/32250)


### PR DESCRIPTION
I usually open tabs for each notable change then copy the links and write descriptions; I must have closed this one by accident.