### PR TITLE
a minor documentation change is not notable

### DIFF
--- a/content/2016-04-11-this-week-in-rust.md
+++ b/content/2016-04-11-this-week-in-rust.md
@@ -72,7 +72,6 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 ## Notable changes
 
-* [Tuples auto-implement `Copy`](https://github.com/rust-lang/rust/pull/32774)
 * [Faster Overlap checking](https://github.com/rust-lang/rust/pull/32748) (fixed a rustc perf regression)
 * [Arc::downgrade no longer loops infinitely](https://github.com/rust-lang/rust/pull/32745)
 * [Function calls no longer need to store all returns on stack](https://github.com/rust-lang/rust/pull/32738)


### PR DESCRIPTION
rust-lang/rust#32774 is a minor documentation change and not major implementation change (which is the obvious interpretation of the current phrasing (at least in my opinion).

By the way - feel free to just close if you disagree and / or don't want to change a published issue.