### PR TITLE
Add Rust Belt Rust CFP reminder announcements

### DIFF
--- a/drafts/2016-04-18-this-week-in-rust.md
+++ b/drafts/2016-04-18-this-week-in-rust.md
@@ -20,6 +20,8 @@ This week's edition was edited by: [Vikrant](https://github.com/nasa42) and [llo
 
 ## News & Blog Posts
 
+* Reminder: [Rust Belt Rust Conference CFP](http://cfp.rust-belt-rust.com/) is open until April 30!
+
 ## Notable New Crates & Project Updates
 
 # Crate of the Week


### PR DESCRIPTION
Hi! I'd love to have Rust Belt Rust's CFP in TWiR until April 30, when it's closing-- I've put it under News but if you think it would be a better fit under Events then I'd be happy to move it (or have it moved for me, whichever :)) Let me know!! Thanks!!!