### PR TITLE
UnsafeCell::get_mut instead of `as_mut`

### DIFF
--- a/drafts/2016-05-16-this-week-in-rust.md
+++ b/drafts/2016-05-16-this-week-in-rust.md
@@ -64,7 +64,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [`Duration::new(..)` now panics instead of wrapping](https://github.com/rust-lang/rust/pull/33072)
 * [`-Wrapping(_)` negation implemented](https://github.com/rust-lang/rust/pull/33067)
 * [`Default` for `&CStr` + `CString`](https://github.com/rust-lang/rust/pull/32990)
-* [`UnsafeCell/Cell.as_mut()`](https://github.com/rust-lang/rust/pull/32565)
+* [`UnsafeCell/Cell.get_mut()`](https://github.com/rust-lang/rust/pull/32565)
 * [`const_eval` fixes](https://github.com/rust-lang/rust/pull/33339)
 * [New armv7-linux-androideabi target](https://github.com/rust-lang/rust/pull/33414)
 


### PR DESCRIPTION
[libs team decided on `get_mut`](https://github.com/rust-lang/rust/pull/32565#issuecomment-217041987)