### PR TITLE
Add missing Ruma updates.

### DIFF
--- a/content/2016-06-27-this-week-in-rust.md
+++ b/content/2016-06-27-this-week-in-rust.md
@@ -48,6 +48,8 @@ This week's edition was edited by: [nasa42](https://github.com/nasa42), [llogiq]
 * [This week in Servo 69](https://blog.servo.org/2016/06/27/twis-69/).
 * [This week in Rust docs 9](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-9).
 * [This week in Rust docs 10](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-10).
+* [This week in Ruma, 2016-06-19](https://www.ruma.io/news/this-week-in-ruma-2016-06-19/).
+* [This week in Ruma, 2016-06-26](https://www.ruma.io/news/this-week-in-ruma-2016-06-26/).
 
 # Crate of the Week
 


### PR DESCRIPTION
The 6/19 update was missed entirely, and the 6/26 update was just released, but including it this week will get everything up to date for TWIR's new Tuesday schedule.