### PR TITLE
Add spectral to 'New Crates & Project Updates'

### DIFF
--- a/drafts/2016-09-06-this-week-in-rust.md
+++ b/drafts/2016-09-06-this-week-in-rust.md
@@ -20,6 +20,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [ref_eq](https://github.com/emosenkis/ref_eq)
 * [releasetag](https://github.com/frehberg/rust-releasetag) Define release-tags for postmortem analysis, extractable from core-files.
 * [bytestool](https://github.com/frehberg/rust-bytestool) Compiler plugins, compile time evaluation, eg. byte_size_of!(b"HELLO"), concat_bytes!(b"HEL", b"LO")
+* [spectral](https://github.com/cfrancia/spectral) Fluent test assertions.
 
 # Crate of the Week
 


### PR DESCRIPTION
It's not on crates.io yet, so I'm hoping that's still okay for this.