### PR TITLE
pelican assets currently doesn't support webassets 0.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Markdown==2.4
 pelican==3.5
 feedgenerator==1.7
-webassets
-cssmin
+webassets==0.11.1
+cssmin==0.2.0


### PR DESCRIPTION
Filed https://github.com/getpelican/pelican-plugins/issues/777 to get this fixed upstream. For now this downgrades webassets (and pins the cssmin version to be safe).