### PR TITLE
Add a section for the new Friend-of-the-Forest

### DIFF
--- a/drafts/2016-10-04-this-week-in-rust.md
+++ b/drafts/2016-10-04-this-week-in-rust.md
@@ -137,6 +137,86 @@ it mentioned here. Email the [Rust Community Team][community] for access.
 
 *Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) to get your job offers listed here!*
 
+# Friends of the Forest
+
+Our community likes to recognize people who have made outstanding contributions
+to the Rust Project, its ecosystem, and its community. These people are
+'friends of the forest'.
+
+This week's friends of the forest were nominated at [RustConf 2016]:
+
+* [dtolnay] and [oli-obk] for taking over most of the maintenance of the [serde] stack
+* [seanmonstar] for answering my too many questions
+* [phildawes] for racer
+* [mitsuhiko] for [redis]
+* [serde] team ([dtolnay], [oli-obk], [erickt])
+* [athemathmo] for [rusty_machine]
+* [carllerche] for [mio]/[tokio]
+* [killercup] for keeping [diesel] running
+* [dikaiosune] - [rusty-dash]
+* [nasa42] and [llogiq] - [This Week In Rust]
+* [WindowsBunny] - being the fuzziest bunny +1 +1 (ed: the +1's are from multiple people)
+* [eddyb] - for knowing everything about rust
+* [chriskrycho] for [New Rustacean]
+* [steveklabnik], Rust documentation superhero
+* [carllerche], [eternaleye], [staticassert]
+* [Matthias Beyer]
+* [llogiq] and [manishearth]
+* [illegalprime] for his work on [rust-websocket]
+* [Mark-Simulacrum] for awesome work on the [compiler performance website]
+* [sfackler] and [briansmith] for enhancing the crypto/security story for Rust.
+  Their efforts have made running Rust in production code much more feasible.
+  sfackler: [rust-openssl], [rust-security-framework], [schannel-rs],
+  [rust-native-tls], briansmith: [ring], [webpki]
+
+[RustConf]: http://rustconf.com/
+[dtolnay]: https://github.com/dtolnay
+[oli-obk]: https://github.com/oli-obk
+[seanmonstar]: https://github.com/seanmonstar
+[phildawes]: https://github.com/phildawes
+[mitsuhiko]: https://github.com/mitsuhiko
+[redis]: https://github.com/mitsuhiko/redis-rs
+[erickt]: https://github.com/erickt
+[serde]: https://github.com/serde-rs
+[athemathmo]: https://github.com/AtheMathmo
+[rusty_machine]: https://github.com/AtheMathmo/rusty-machine
+[carllerche]: https://github.com/carllerche
+[mio]: https://github.com/carllerche/mio
+[tokio]: https://github.com/tokio-rs
+[killercup]: https://github.com/killercup
+[diesel]: http://diesel.rs/
+[dikaiosune]: https://github.com/dikaiosune
+[rusty-dash]: http://rusty-dash.com/
+[nasa42]: https://github.com/nasa42
+[llogiq]: https://github.com/llogiq
+[This Week In Rust]: https://this-week-in-rust.org/
+[WindowsBunny]: https://github.com/retep998
+[eddyb]: https://github.com/eddyb
+[chriskrycho]: https://github.com/chriskrycho
+[New Rustacean]: http://www.newrustacean.com/
+[steveklabnik]: https://github.com/steveklabnik
+[eternaleye]: https://github.com/eternaleye
+[staticassert]: https://github.com/insaneinside
+[Matthias Beyer]: http://beyermatthias.de
+[llogiq]: https://github.com/llogiq
+[manishearth]: https://github.com/manishearth
+[illegalprime]: https://github.com/illegalprime
+[rust-websocket]: https://github.com/cyderize/rust-websocket
+[Mark-Simulacrum]: https://github.com/Mark-Simulacrum
+[compiler performance website]: http://perf.rust-lang.org/
+[sfackler]: https://github.com/sfackler
+[briansmith]: https://github.com/briansmith
+[rust-openssl]: https://github.com/sfackler/rust-openssl
+[rust-security-framework]: https://github.com/sfackler/rust-security-framework
+[schannel-rs]: https://github.com/steffengy/schannel-rs
+[rust-native-tls]: https://github.com/sfackler/rust-native-tls
+[ring]: https://github.com/briansmith/ring
+[webpki]: https://github.com/briansmith/webpki
+
+[Submit your Friends-of-the-Forest nominations for next week][foft]!
+
+[foft]: https://users.rust-lang.org/t/twir-friends-of-the-forest/7295
+
 # Quote of the Week
 
 > You can actually return Iterators without summoning one of the Great Old Ones now, which is pretty cool.

--- a/drafts/2016-10-04-this-week-in-rust.md
+++ b/drafts/2016-10-04-this-week-in-rust.md
@@ -143,7 +143,7 @@ Our community likes to recognize people who have made outstanding contributions
 to the Rust Project, its ecosystem, and its community. These people are
 'friends of the forest'.
 
-This week's friends of the forest were nominated at [RustConf 2016]:
+This week's friends of the forest are:
 
 * [dtolnay] and [oli-obk] for taking over most of the maintenance of the [serde] stack
 * [seanmonstar] for answering my too many questions
@@ -168,6 +168,27 @@ This week's friends of the forest were nominated at [RustConf 2016]:
   Their efforts have made running Rust in production code much more feasible.
   sfackler: [rust-openssl], [rust-security-framework], [schannel-rs],
   [rust-native-tls], briansmith: [ring], [webpki]
+* from [llogiq][llogiq-nominated]:
+
+> I'd like to nominate [Veedrac] for his awesome contributions to various
+> performance-related endeavors.
+
+* from [codingcampbell][codingcampbell-nominated]:
+
+> I'd like to highlight [tomaka] for his numerous projects ([glium], [vulkano],
+> [glutin]). I know he's also involved in some other crates I take for granted,
+> like [gl_generator].
+>
+> I like to play with gamedev, but I am a newcomer to OpenGL things and I have
+> been very grateful for projects like [glium] and [gl_generator] that not only
+> give me a good starting point, but through various documentation has informed
+> me of OpenGL pitfalls.
+>
+> He recently wrote a [post-mortem][glium-postmortem] for [glium], which I think
+> is good as a matter of reflection, but I'm still very impressed with that
+> project, and the others he is tirelessly contributing to.
+>
+> Well done!
 
 [RustConf]: http://rustconf.com/
 [dtolnay]: https://github.com/dtolnay
@@ -212,6 +233,15 @@ This week's friends of the forest were nominated at [RustConf 2016]:
 [rust-native-tls]: https://github.com/sfackler/rust-native-tls
 [ring]: https://github.com/briansmith/ring
 [webpki]: https://github.com/briansmith/webpki
+[llogiq-nominated]: https://github.com/rust-community/team/issues/77#issuecomment-250074590
+[Veedrac]: https://github.com/Veedrac
+[codingcampbell-nominated]: https://users.rust-lang.org/t/twir-friends-of-the-forest/7295/2
+[tomaka]: https://github.com/tomaka
+[glium]: https://github.com/tomaka/glium
+[vulkano]: https://github.com/tomaka/vulkano
+[glutin]: https://github.com/tomaka/glutin
+[gl_generator]: https://github.com/brendanzab/gl-rs
+[glium-postmortem]: https://users.rust-lang.org/t/glium-post-mortem/7063
 
 [Submit your Friends-of-the-Forest nominations for next week][foft]!
 


### PR DESCRIPTION
The community team is starting a new Friend-of-the-Forest tradition, where the broader rust community recognizes outstanding contributions to our ecosystem. This is the first batch we collected from RustConf.