### PR TITLE
Adding link to crates.io RFC-ish PR

### DIFF
--- a/drafts/2017-01-03-this-week-in-rust.md
+++ b/drafts/2017-01-03-this-week-in-rust.md
@@ -96,6 +96,7 @@ decision. Express your opinions now. [This week's FCPs][fcp] are:
 * [Macros by example 2.0. A replacement for `macro_rules!`](https://github.com/rust-lang/rfcs/pull/1584).
 * [Allow coercing non-capturing closures to function pointers](https://github.com/rust-lang/rfcs/pull/1558).
 * [Add Rvalue-static-promotion](https://github.com/rust-lang/rfcs/pull/1414).
+* [What categories should be available on crates.io? ](https://github.com/rust-lang/crates.io/pull/488)
 
 ## New RFCs
 


### PR DESCRIPTION
Hi! I have [this crates.io PR](https://github.com/rust-lang/crates.io/pull/488) that's not really an RFC but I'd like input from the community on it. I'm trying to wrap it up, so I'm declaring a final comment period and I'd love to have it in this week's TWiR.

It looks like this file still has last week's FCP RFCs in this section, is it ok if I just add mine at the bottom here? Will it get overwritten when this gets updated to this week's?

Feel free to move the link to another section if it isn't appropriate here since it's not a real RFC!! Thanks!!! ❤️ 