### PR TITLE
Add 'answer of the week'

### DIFF
--- a/drafts/2017-01-17-this-week-in-rust.md
+++ b/drafts/2017-01-17-this-week-in-rust.md
@@ -26,6 +26,10 @@ This week's Crate of the Week is [trust](https://github.com/japaric/trust), a Tr
 
 [submit_crate]: https://users.rust-lang.org/t/crate-of-the-week/2704
 
+# Answer of the Week
+
+This section highlights an exceptional answer to a question about Rust. This week Francis Gagné explains on StackOverflow [how to make something public within a crate, but private outside it](http://stackoverflow.com/a/41667202/265521).
+
 # Call for Participation
 
 Always wanted to contribute to open-source projects but didn't know where to start?


### PR DESCRIPTION
I've had two amazing answers from people on SO where the quality is such that I wish it were in the official documentation. Anyway I think it would be nice to highlight this useful information, and maybe encourage more people to answer Rust questions.

Alternatively it could just go in the News & Blog Posts bit like last time.