### PR TITLE
Add Bryant Mairs as a new contributor

### DIFF
--- a/content/2017-01-31-this-week-in-rust.md
+++ b/content/2017-01-31-this-week-in-rust.md
@@ -95,6 +95,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 
 ## New Contributors
 
+* Bryant Mairs
 * Caleb Reach
 * Collin J. Sutton
 * Denis Andrejew


### PR DESCRIPTION
I contributed the "Improve cargo error message on different dependency source paths", which is listed here, so I figured I'd add my name as a new contributor (haven't contributed before).