### PR TITLE
174: remove Cornell job listing

### DIFF
--- a/content/2017-03-21-this-week-in-rust.md
+++ b/content/2017-03-21-this-week-in-rust.md
@@ -185,6 +185,7 @@ it mentioned here. Email the [Rust Community Team][community] for access.
 
 # Rust Jobs
 
+* [Rust developers at Cornell Tech New York](https://twitter.com/sahuguet/status/839198110819762177).
 * [Rust engineer at a startup in San Francisco](https://users.rust-lang.org/t/jobs-in-rust-development/3628/4).
 
 *Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) to get your job offers listed here!*

--- a/content/2017-03-21-this-week-in-rust.md
+++ b/content/2017-03-21-this-week-in-rust.md
@@ -185,7 +185,6 @@ it mentioned here. Email the [Rust Community Team][community] for access.
 
 # Rust Jobs
 
-* [Rust developers at Cornell Tech New York](https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/job/New-York-City-Cornell-Tech/Developer-or-Senior-Developer-in-Residence-Cornell-Tech--New-York--NY_WDR-00010241).
 * [Rust engineer at a startup in San Francisco](https://users.rust-lang.org/t/jobs-in-rust-development/3628/4).
 
 *Tweet us at [@ThisWeekInRust](https://twitter.com/ThisWeekInRust) to get your job offers listed here!*


### PR DESCRIPTION
It doesn't mention Rust at all.