### PR TITLE
Add runtime-fmt crate announcement

### DIFF
--- a/drafts/2017-04-11-this-week-in-rust.md
+++ b/drafts/2017-04-11-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [Announcing `runtime-fmt`, a crate for using runtime format strings](https://www.platymuus.com/posts/2017/runtime-fmt/)
+
 # Crate of the Week
 
 This week's Crate of this Week is [fst](https://github.com/BurntSushi/fst), which contains Finite State Transducers and assorted algorithms that use them (e.g. fuzzy text search). Thanks to [Jules Kerssemakers](https://users.rust-lang.org/users/juleskers) for the suggestion!


### PR DESCRIPTION
Not really sure how TWiR usually gates what blog posts appear, but I would love to see this crate announcement in it! I think it has potential to fill its specific niche.