### PR TITLE
Updated link to tarpaulin blog post.

### DIFF
--- a/content/2017-07-25-this-week-in-rust.md
+++ b/content/2017-07-25-this-week-in-rust.md
@@ -19,7 +19,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * <img alt="balloon" class="emoji" title=":balloon:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/balloon.png?v=0"><img alt="tada" class="emoji" title=":tada:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/tada.png?v=0"> [Announcing Rust 1.19](https://blog.rust-lang.org/2017/07/20/Rust-1.19.html). <img alt="tada" class="emoji" title=":tada:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/tada.png?v=0"><img alt="balloon" class="emoji" title=":balloon:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/balloon.png?v=0">
 * [Towards a second edition of the compiler](https://internals.rust-lang.org/t/towards-a-second-edition-of-the-compiler/5582).
 * [Introducing PyO3 - Rust bindings for the Python interpreter](https://www.reddit.com/r/rust/comments/6p3rjp/pyo3_python_rust_binding/).
-* [Introducting Tarpaulin - a code coverage tool for Rust](https://xd009642.github.io/2017/07/20/introducting-tarpaulin.html).
+* [Introducing Tarpaulin - a code coverage tool for Rust](https://xd009642.github.io/2017/07/20/introducing-tarpaulin.html).
 * [Measuring test coverage of Rust libraries](https://jbp.io/2017/07/19/measuring-test-coverage-of-rust-programs).
 * [Using Rocket + error_chain for REST APIs in Rust](https://jamesmunns.com/update/2017/07/22/rocket-plus-error-chain.html).
 * [Gfx-rs - the new low-level core](https://gfx-rs.github.io/2017/07/24/low-level.html).


### PR DESCRIPTION
So I noticed a typo in the tarpaulin blog post title and updated it and realised it broke a link on a previous this week in rust. This pull request remedies that so that people looking back at previous issues don't find the content inaccessible.