### PR TITLE
Add Rust FFI/Wireshark project

### DIFF
--- a/drafts/2017-08-29-this-week-in-rust.md
+++ b/drafts/2017-08-29-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts  
 
+* [Rust FFI in a C Wireshark dissector](https://github.com/sevagh/wireshark-dissector-rs/blob/master/README.md)
+
 # Crate of the Week
 
 This week's crate is [pest](https://crates.io/crates/pest), a PEG-based parsing library. Thanks to [Laurent Wandrebeck](https://users.rust-lang.org/u/lwandrebeck) for the suggestion.


### PR DESCRIPTION
I added a link to my recent project/article (it's not on my blog but it's a README.md intended to read like an article) and codebase on how to make Rust run inside a C Wireshark dissector.