### PR TITLE
Add link to Pikkr library

### DIFF
--- a/drafts/2017-09-05-this-week-in-rust.md
+++ b/drafts/2017-09-05-this-week-in-rust.md
@@ -17,6 +17,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ## News & Blog Posts
 
 * [Generating C bindings for Rust crates with cbindgen](http://dreamingofbits.com/post/generating-c-bindings-for-rust-crates-with-cbindgen/)
+* [Fast JSON parser which picks up values directly without performing tokenization](https://github.com/pikkr/pikkr)
 
 # Crate of the Week
 


### PR DESCRIPTION
I am not sure whether this belongs under News & Blog Posts, feel free to close if not. The library was [announced this week on the users forum.](https://users.rust-lang.org/t/json-parser-which-picks-up-values-directly-without-performing-tokenization-in-rust/12680?u=dtolnay) It is exciting in using AVX2 simd instructions in a central way to achieve astonishingly good performance. It demonstrates that Rust is a feasible language for such work. The readme gives a link to the research it is built on.

I used the subtitle from the repo but something like this may work better:

> Fast JSON parser using AVX2 instructions to perform lookups