### PR TITLE
Add missing name

### DIFF
--- a/content/2017-11-07-this-week-in-rust.md
+++ b/content/2017-11-07-this-week-in-rust.md
@@ -92,6 +92,7 @@ If you are a Rust project owner and are looking for contributors, please submit 
 ## New Contributors
 
 * David Wood
+* Fredrik Larsson
 * Jonathan Behrens
 * Lance John
 * laurent


### PR DESCRIPTION
My name isn't in the list of new contributors even though my first contribution is in the list of updates from Rust core.