### PR TITLE
add link to Rusoto 0.32.0 release

### DIFF
--- a/drafts/2018-03-13-this-week-in-rust.md
+++ b/drafts/2018-03-13-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+- [Rusoto 0.32.0 - now exclusively using non-blocking I/O based on `futures` and `tokio`](https://github.com/rusoto/rusoto/releases/tag/rusoto-v0.32.0)
+
 # Crate of the Week
 
 This week's crate is [trace](https://github.com/gsingh93/trace), a crate to allow for quick debug outputs without `println!`. Thanks to [gilescope](https://users.rust-lang.org/u/gilescope) for the suggestion.


### PR DESCRIPTION
We released Rusoto 0.32.0 earlier this week.

Unfortunately we didn't have much of an announcement besides the release notes, so I hope you don't mind me linking to those!