### PR TITLE
Add Rust/WASM course

### DIFF
--- a/drafts/2018-05-08-this-week-in-rust.md
+++ b/drafts/2018-05-08-this-week-in-rust.md
@@ -137,6 +137,7 @@ The community team is trying to improve outreach to meetup organisers. Please fi
 * [May 16. Vancouver, CA - Rust Study/Hack/Hang-out night](https://www.meetup.com/Vancouver-Rust/events/ckwdlpyxhbvb/).
 * [May 17. Cambridge, GB - Cambridge Rust Meetup](https://www.meetup.com/Cambridge-Rust-Meetup/events/pzwshpyxhbwb/).
 * **[May 27. Paris, FR - RustFest Paris 2018](https://paris.rustfest.eu/)**.
+* [May 30./31. Rust/WASM course around JSConf.EU](https://ti.to/asquera-event-ug/rust-wasm-wwwtf-2018/).
 
 If you are running a Rust event please add it to the [calendar] to get
 it mentioned here. Email the [Rust Community Team][community] for access.


### PR DESCRIPTION
Adds the public Rust/WASM course around JSConf.EU. This is a commercial course.