### PR TITLE
Add blog post for Servo HTTP cache

### DIFF
--- a/drafts/2018-07-10-this-week-in-rust.md
+++ b/drafts/2018-07-10-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [Programming Servo: an HTTP cache](https://medium.com/programming-servo/programming-servo-an-http-cache-edb52a7f267f).
+
 # Crate of the Week
 
 This week's crate is [datafrog](https://crates.io/crates/datafrog), the lightweight embeddable datalog engine that powers Rust's non-lexical lifetimes (NLL). Thanks to [Jules Kerssemakers](https://users.rust-lang.org/u/juleskers) for the suggestion.


### PR DESCRIPTION
From https://medium.com/programming-servo/programming-servo-an-http-cache-edb52a7f267f

It's something I wrote based on my own experience with https://github.com/servo/servo/pull/18676
