### PR TITLE
Correct ECMAScript futures to ECMAScript promises

### DIFF
--- a/content/2018-08-21-this-week-in-rust.md
+++ b/content/2018-08-21-this-week-in-rust.md
@@ -29,7 +29,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 # Crate of the Week
 
-This week's crate is [wasm-bindgen-futures](https://crates.io/crates/wasm-bindgen-futures), a crate to make ECMAScript futures and Rust futures interoperate. Thanks to [Vikrant](https://users.rust-lang.org/t/crate-of-the-week/2704/438) for the suggestion!
+This week's crate is [wasm-bindgen-futures](https://crates.io/crates/wasm-bindgen-futures), a crate to make ECMAScript promises and Rust futures interoperate. Thanks to [Vikrant](https://users.rust-lang.org/t/crate-of-the-week/2704/438) for the suggestion!
 
 [Submit your suggestions and votes for next week][submit_crate]!
 


### PR DESCRIPTION
In [This Week in Rust 248](https://this-week-in-rust.org/blog/2018/08/21/this-week-in-rust-248/) there is a mention of crate [wasm-bindgen-futures](https://crates.io/crates/wasm-bindgen-futures), which has futures and promises mixed up.