### PR TITLE
Add new blog post

### DIFF
--- a/drafts/2019-02-19-this-week-in-rust.md
+++ b/drafts/2019-02-19-this-week-in-rust.md
@@ -15,6 +15,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 # Updates from Rust Community
 
 ## News & Blog Posts
+* [Porting a CHIP-8 emulator to Rust](https://ntcore.com/?p=594)
 
 # Crate of the Week
 


### PR DESCRIPTION
Add a reference to Daniel Pistelli's, "Porting a CHIP-8 emulator to Rust", blog post