### PR TITLE
added link "Run Rust code in Pandoc Markdown documents" under News

### DIFF
--- a/drafts/2019-02-26-this-week-in-rust.md
+++ b/drafts/2019-02-26-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [Run Rust code in Pandoc Markdown documents](https://github.com/gpoore/codebraid)
+
 # Crate of the Week
 
 This week's crate is [num-format](https://github.com/bcmyers/num-format), a crate to format numbers to international standards. Thanks to [Vikrant](https://users.rust-lang.org/t/crate-of-the-week/2704/485) for the suggestion!


### PR DESCRIPTION
I've created a program that makes Rust code in Markdown documents executable, and I think this might be of interest to the community. This is sort of like R Markdown for Rust, if you're familiar with that. This can be useful for writing things like tutorials. Here's an [example of what is possible](http://htmlpreview.github.io/?https://github.com/gpoore/codebraid/blob/master/examples/rust.html).