### PR TITLE
Fix date for Seattle Rust meetup

### DIFF
--- a/content/2019-03-05-this-week-in-rust.md
+++ b/content/2019-03-05-this-week-in-rust.md
@@ -120,7 +120,7 @@ decision. Express your opinions now.
 ### North America
 
 * [Mar  9. 200 University Ave W, Waterloo, CN - Workshop: Introduction to Game Development in Rust](https://www.meetup.com/Rust-KW/events/259335419/).
-* [Mar 11. Seattle, US - Seattle Rust Meetup](https://www.meetup.com/Seattle-Rust-Meetup/events/nzfspqyzfbpb/).
+* [Mar 12. Seattle, US - Seattle Rust Meetup](https://www.meetup.com/Seattle-Rust-Meetup/events/nzfspqyzfbpb/).
 * [Mar 13. Ciudad de México, MX - Study group RustMX](https://www.meetup.com/Rust-MX/events/259473143/).
 * [Mar 14. Columbus, US - Columbus Rust Society](https://www.meetup.com/columbus-rs/events/dbcfrpyzfbsb/).
 * [Mar 14. Utah, US - Utah Rust monthly meetup](https://www.meetup.com/utahrust/events/258703993/).


### PR DESCRIPTION
The Seattle Rust Meetup _used_ to meet on a Monday, but recently moved to Tuesdays. This just fixes the consequent off-by-one error.

Thanks for including us on the list!