### PR TITLE
Add announcement for Colorado Gold Rust CFP

### DIFF
--- a/drafts/2019-04-16-this-week-in-rust.md
+++ b/drafts/2019-04-16-this-week-in-rust.md
@@ -18,6 +18,10 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+The [CFP for Colorado Gold Rust](https://cfp.cogoldrust.com/events/cogoldrust-2019) is open now!
+Submit a talk today! The organizers are also looking for volunteers to help people draft talk proposals.
+If you can help out [send them an email](mailto:coloradogoldrust@gmail.com) or DM them on Twitter at [@COGoldRust](https://twitter.com/cogoldrust)!
+
 # Crate of the Week
 
 This week's crate is [interact](https://github.com/interact-rs/interact), a framework for online introspection of the running program state. Thanks to [Willi Kappler](https://users.rust-lang.org/t/crate-of-the-week/2704/513) for the suggestion!


### PR DESCRIPTION
This PR provides a call to action to submit talk proposals to Colorado Gold Rust & a request for volunteers to help people draft proposals under the `News & Blog Posts` section.