### PR TITLE
Add blogpost on Stream combinators using for await syntax

### DIFF
--- a/drafts/2019-07-16-this-week-in-rust.md
+++ b/drafts/2019-07-16-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [Stream combinators implemented using for await syntax](https://www.reddit.com/r/rust/comments/cbvhq9/stream_combinators_implemented_using_for_await/)
+
 # Crate of the Week
 
 This week's CotW is not a crate but [Rustexp](https://rustexp.lpil.uk/) site, a Rust regular expression editor & tester.


### PR DESCRIPTION
The following article shows how Stream combinators can be implemented using for await syntax.