### PR TITLE
Add Rust+GNOME workshop to dates

### DIFF
--- a/drafts/2019-08-12-this-week-in-rust.md
+++ b/drafts/2019-08-12-this-week-in-rust.md
@@ -108,6 +108,7 @@ decision. Express your opinions now.
 * [Aug 19. Berlin, DE - Rust Berlin - Rust for Decentralised Technology](https://www.meetup.com/Rust-Berlin/events/263390533).
 * [Aug 21. Berlin, DE - In Rust We Trust - VM on Blockchain](https://www.meetup.com/Rust-in-Blockchain-Berlin/events/263526816/).
 * [Aug 26. Thessaloniki, GR - Rust + GNOME Workshop at GUADEC](https://wiki.gnome.org/GUADEC/2019/Hackingdays/RustGtkGstWorkshop).
+* [Aug 27. Thessaloniki, GR - Rust + GNOME BoF at GUADEC](https://wiki.gnome.org/GUADEC/2019/Hackingdays/RustBoF).
 
 ### North America
 

--- a/drafts/2019-08-12-this-week-in-rust.md
+++ b/drafts/2019-08-12-this-week-in-rust.md
@@ -107,6 +107,7 @@ decision. Express your opinions now.
 * [Aug 21. Berlin, DE - OpenTechSchool Berlin - Rust Hack and Learn](https://www.meetup.com/opentechschool-berlin/events/gkkttqyzlbcc/).
 * [Aug 19. Berlin, DE - Rust Berlin - Rust for Decentralised Technology](https://www.meetup.com/Rust-Berlin/events/263390533).
 * [Aug 21. Berlin, DE - In Rust We Trust - VM on Blockchain](https://www.meetup.com/Rust-in-Blockchain-Berlin/events/263526816/).
+* [Aug 26. Thessaloniki, GR - Rust + GNOME Workshop at GUADEC](https://wiki.gnome.org/GUADEC/2019/Hackingdays/RustGtkGstWorkshop).
 
 ### North America
 


### PR DESCRIPTION
26 August in Thessaloniki at GUADEC.

https://wiki.gnome.org/GUADEC/2019/Hackingdays/RustGtkGstWorkshop