### PR TITLE
Pre-/Post-Conf Events: sustainable 🚄 train travels from and to RustFest Barcelona

### DIFF
--- a/drafts/2019-08-20-this-week-in-rust.md
+++ b/drafts/2019-08-20-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [Pre-/Post-Conf Events: sustainable 🚄 train travels from and to RustFest Barcelona](https://blog.rustfest.eu/pre-post-conf-events-sustainable-train-travels)
+
 # Crate of the Week
 
 This week's crate is [topgrade](https://crates.io/crates/topgrade), a command-line program to upgrade all the things.


### PR DESCRIPTION
The news will be public in 8 hours:
https://github.com/RustFestEU/blog.rustfest.eu/pull/84