### PR TITLE
runtime -> mun_runtime

### DIFF
--- a/content/2019-09-24-this-week-in-rust.md
+++ b/content/2019-09-24-this-week-in-rust.md
@@ -27,7 +27,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 # Crate of the Week
 
-This week's crate is [runtime](https://github.com/mun-lang/runtime), an experimental hot-reloading oriented runtime in Rust.
+This week's crate is [mun_runtime](https://github.com/mun-lang/runtime), an experimental hot-reloading oriented runtime in Rust.
 
 Thanks to [Vikrant](https://users.rust-lang.org/t/crate-of-the-week/2704/628) for the suggestion!
 


### PR DESCRIPTION
`mun_runtime` is the actual name of the crate in the repo, and it should not be confused with [runtime](https://crates.io/crates/runtime)