### PR TITLE
Adds the October edition of Zagreb Rust Meetup

### DIFF
--- a/drafts/2019-10-01-this-week-in-rust.md
+++ b/drafts/2019-10-01-this-week-in-rust.md
@@ -122,6 +122,7 @@ decision. Express your opinions now.
 * [Oct  4. Toulouse, FR - Toulouse Rust Meetup - Future<Output = Rust>](https://www.meetup.com/Toulouse-Rust-Meetup/events/264780064).
 * [Oct  4. Darmstadt, DE - Hacktoberfest for Rustaceans](https://www.meetup.com/Rust-Rhein-Main/events/265052778).
 * [Oct  5. Kharkiv, UA - PeerLab Kharkiv #Rust: AsyncIO](https://dou.ua/calendar/28904/).
+* [Oct  9. Zagreb, HR - impl Zagreb for Rust: Rust, FFmpeg i TensorFlow](https://www.meetup.com/Zagreb-Rust-Meetup/events/265307360/).
 * [Oct 10. Helsinki, FI - Finland Rust-lang Group - October meetup](https://www.meetup.com/Finland-Rust-Meetup/events/265091401/).
 * [Oct 10. Warsaw, PL - Rust Warsaw - reboot](https://www.meetup.com/Rust-Warsaw/events/265091321/).
 


### PR DESCRIPTION
Adds a link to the Zagreb Rust Meetup event for October.

Sorry about the last-minute addition; I hope it'll make it in. :)