### PR TITLE
308: remove mention of minimizing rust-std

### DIFF
--- a/content/2019-10-15-this-week-in-rust.md
+++ b/content/2019-10-15-this-week-in-rust.md
@@ -81,7 +81,6 @@ If you are a Rust project owner and are looking for contributors, please submit 
 * [Stabilize `mem::take`](https://github.com/rust-lang/rust/pull/64716)
 * [Implement (`HashMap`) `Entry::insert`](https://github.com/rust-lang/rust/pull/64656)
 * [improve performance of signed `saturating_mul`](https://github.com/rust-lang/rust/pull/65312)
-* [dist: minimize the `rust-std` component](https://github.com/rust-lang/rust/pull/64823)
 
 ## Approved RFCs
 


### PR DESCRIPTION
That PR has been reverted in https://github.com/rust-lang/rust/pull/65342 due to widespread breakage.